### PR TITLE
Remove unnecessary tasks on the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,3 @@ dev-deps:
 
 clean:
 	go clean
-	rm -f gpb-firewalls-microservice
-
-dist-clean:
-	rm -rf pkg src bin
-
-ci-deps:


### PR DESCRIPTION
Some small details:
- Empty ci-deps task is not necessary
- Also dist-clean is pointless as we use `go install` instead `go build`
